### PR TITLE
Add badges to entries and Twitterbot

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # NaNoGenMo 2019
 
 [![entries: completed][~completed]](https://github.com/NaNoGenMo/2019/labels/completed)
-[![entries: preview][~preview]](https://github.com/NaNoGenMo/2019/labels/completed)
-[![issues: admin][~admin]](https://github.com/NaNoGenMo/2019/labels/completed)
+[![entries: preview][~preview]](https://github.com/NaNoGenMo/2019/labels/preview)
+[![issues: admin][~admin]](https://github.com/NaNoGenMo/2019/labels/admin)
 [![twitter: nanogenmobot][~twitter]](https://twitter.com/nanogenmobot)
 
 [~completed]: https://img.shields.io/badge/entries-completed-0e8a16.svg

--- a/README.md
+++ b/README.md
@@ -1,5 +1,15 @@
 # NaNoGenMo 2019
 
+[![entries: completed][~completed]](https://github.com/NaNoGenMo/2019/labels/completed)
+[![entries: preview][~preview]](https://github.com/NaNoGenMo/2019/labels/completed)
+[![issues: admin][~admin]](https://github.com/NaNoGenMo/2019/labels/completed)
+[![twitter: nanogenmobot][~twitter]](https://twitter.com/nanogenmobot)
+
+[~completed]: https://img.shields.io/badge/entries-completed-0e8a16.svg
+[~preview]: https://img.shields.io/badge/entries-preview-c5def5.svg
+[~admin]: https://img.shields.io/badge/issues-admin-fef2c0.svg
+[~twitter]: https://img.shields.io/badge/twitter-NaNoGenMoBot-00aced.svg?logo=twitter
+
 National Novel Generation Month - based on [an idea Darius tweeted on a whim](https://twitter.com/tinysubversions/status/396305662000775168), where people are challenged to write code that writes a novel.
 
 <p align="center"><a href="https://twitter.com/tinysubversions/status/396305662000775168"><img src="https://nanogenmo.github.io/tweet.png" width="600" height="338" alt="Hey, who wants to join me in NaNoGenMo: spend the month writing code that generates a 50k word novel, share the novel & the code at the end"></a></p>


### PR DESCRIPTION
Preview:

![image](https://user-images.githubusercontent.com/1324225/69911920-18c60000-142b-11ea-957c-f84904f5f784.png)

https://github.com/NaNoGenMo/2019/blob/add-badges/README.md

It'd be good for the links to be relative, so we don't need to replace 2019 with 2020 etc., but I don't know if that's possible.
