### PR TITLE
Merge pull request #151 from NaNoGenMo/update-badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # NaNoGenMo 2019
 
-[![entries: completed][~completed]](https://github.com/NaNoGenMo/2019/labels/completed)
-[![entries: preview][~preview]](https://github.com/NaNoGenMo/2019/labels/preview)
-[![issues: admin][~admin]](https://github.com/NaNoGenMo/2019/labels/admin)
+[![entries: completed][~completed]](https://github.com/NaNoGenMo/2019/issues?q=label%3Acompleted)
+[![entries: preview][~preview]](https://github.com/NaNoGenMo/2019/issues?q=label%3Apreview)
+[![issues: admin][~admin]](https://github.com/NaNoGenMo/2019/issues?q=label%3Aadmin)
 [![twitter: nanogenmobot][~twitter]](https://twitter.com/nanogenmobot)
 
 [~completed]: https://img.shields.io/badge/entries-completed-0e8a16.svg


### PR DESCRIPTION
People sometimes close their entry issues, presumably to clean up their https://github.com/issues list.

We've sometimes re-opened issues during (and possibly shortly after) _the month_ to help people find and browse entries, but I've not worried about when it happens some time later.

So let's at least update the badges to show both open and closed issues.

I'll update the older repos after merging this.